### PR TITLE
let's add GTIndex missing methods, nullable qualifiers, et al. and fix some memory leaks

### DIFF
--- a/ObjectiveGit/GTIndex.h
+++ b/ObjectiveGit/GTIndex.h
@@ -28,8 +28,9 @@
 //
 
 #import <Foundation/Foundation.h>
-#include "git2/types.h"
+#include "git2/index.h"
 
+@class GTOID;
 @class GTIndexEntry;
 @class GTRepository;
 @class GTTree;
@@ -44,6 +45,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// The file URL for the index if it exists on disk; nil otherwise.
 @property (nonatomic, readonly, copy, nullable) NSURL *fileURL;
+
+/// The index checksum
+@property (nonatomic, readonly, strong, nullable) GTOID *checksum;
 
 /// The number of entries in the index.
 @property (nonatomic, readonly) NSUInteger entryCount;
@@ -202,7 +206,53 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// Returns `YES` in the event of successful enumeration or no conflicts in the
 /// index, `NO` in case of error.
-- (BOOL)enumerateConflictedFilesWithError:(NSError **)error usingBlock:(void (^)(GTIndexEntry *ancestor, GTIndexEntry *ours, GTIndexEntry *theirs, BOOL *stop))block;
+- (BOOL)enumerateConflictedFilesWithError:(NSError **)error usingBlock:(void (^)(GTIndexEntry * _Nullable ancestor, GTIndexEntry * _Nullable ours, GTIndexEntry * _Nullable theirs, BOOL *stop))block;
+
+/// An enum for use with addPathspecs:flags:error:passingTest: below
+/// See index.h for documentation of each individual git_index_add_option_t flag.
+typedef NS_OPTIONS(NSInteger, GTIndexAddOptionFlags) {
+	GTIndexAddOptionDefault = GIT_INDEX_ADD_DEFAULT,
+	GTIndexAddOptionForce = GIT_INDEX_ADD_FORCE,
+	GTIndexAddOptionDisablePathspecMatch = GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH,
+	GTIndexAddOptionCheckPathspec = GIT_INDEX_ADD_CHECK_PATHSPEC
+};
+
+/// Add or update index entries matching files in the working directory.
+/// This method will immediately fail if the index's repo is bare.
+///
+/// pathspecs - An `NSString` array of path patterns. (E.g: *.c)
+///             If nil is passed in, all index entries will be updated.
+/// flags     - A combination of GTIndexAddOptionFlags flags
+/// block     - A block run each time a pathspec is matched; before the index is
+///             added/updated. The `matchedPathspec` parameter is a string indicating
+///             what the pathspec (from `pathspecs`) matched. If you pass in NULL
+///             in to the `pathspecs` parameter this parameter will be nil.
+///             The `path` parameter is a repository relative path to the file
+///             about to be added/updated.
+///             The `stop` parameter can be set to `YES` to abort the operation.
+///             Return `YES` to update the given path, or `NO` to skip it. May be nil.
+/// error     - When something goes wrong, this parameter is set. Optional.
+///
+/// Returns `YES` in the event that everything has gone smoothly. Otherwise, `NO`.
+- (BOOL)addPathspecs:(nullable NSArray<NSString*> *)pathspecs flags:(GTIndexAddOptionFlags)flags error:(NSError **)error passingTest:(nullable BOOL (^)(NSString * _Nullable matchedPathspec, NSString *path, BOOL *stop))block;
+
+/// Remove all matching index entries.
+/// This method will immediately fail if the index's repo is bare.
+///
+/// pathspecs - An `NSString` array of path patterns. (E.g: *.c)
+///             If nil is passed in, all index entries will be updated.
+/// block     - A block run each time a pathspec is matched; before the index is
+///             removed. The `matchedPathspec` parameter is a string indicating
+///             what the pathspec (from `pathspecs`) matched. If you pass in NULL
+///             in to the `pathspecs` parameter this parameter will be nil.
+///             The `path` parameter is a repository relative path to the file
+///             about to be updated.
+///             The `stop` parameter can be set to `YES` to abort the operation.
+///             Return `YES` to update the given path, or `NO` to skip it. May be nil.
+/// error     - When something goes wrong, this parameter is set. Optional.
+///
+/// Returns `YES` in the event that everything has gone smoothly. Otherwise, `NO`.
+- (BOOL)removePathspecs:(nullable NSArray<NSString*> *)pathspecs error:(NSError **)error passingTest:(nullable BOOL (^)(NSString * _Nullable matchedPathspec, NSString *path, BOOL *stop))block;
 
 /// Update all index entries to match the working directory.
 /// This method will immediately fail if the index's repo is bare.
@@ -212,7 +262,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// block     - A block run each time a pathspec is matched; before the index is
 ///             updated. The `matchedPathspec` parameter is a string indicating
 ///             what the pathspec (from `pathspecs`) matched. If you pass in NULL
-///             in to the `pathspecs` parameter this parameter will be empty.
+///             in to the `pathspecs` parameter this parameter will be nil.
 ///             The `path` parameter is a repository relative path to the file
 ///             about to be updated.
 ///             The `stop` parameter can be set to `YES` to abort the operation.
@@ -220,7 +270,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// error     - When something goes wrong, this parameter is set. Optional.
 ///
 /// Returns `YES` in the event that everything has gone smoothly. Otherwise, `NO`.
-- (BOOL)updatePathspecs:(nullable NSArray<NSString*> *)pathspecs error:(NSError **)error passingTest:(nullable BOOL (^)(NSString *matchedPathspec, NSString *path, BOOL *stop))block;
+- (BOOL)updatePathspecs:(nullable NSArray<NSString*> *)pathspecs error:(NSError **)error passingTest:(nullable BOOL (^)(NSString * _Nullable matchedPathspec, NSString *path, BOOL *stop))block;
 
 #pragma mark Deprecations
 - (nullable GTIndexEntry *)entryWithName:(NSString *)name __deprecated_msg("use entryWithPath: instead.");

--- a/ObjectiveGit/GTIndex.m
+++ b/ObjectiveGit/GTIndex.m
@@ -121,6 +121,14 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 
 #pragma mark Entries
 
+- (GTOID *)checksum {
+	const git_oid *oid = git_index_checksum(self.git_index);
+	if (oid != NULL)
+		return [GTOID oidWithGitOid:oid];
+	else
+		return nil;
+}
+
 - (NSUInteger)entryCount {
 	return git_index_entrycount(self.git_index);
 }
@@ -308,17 +316,17 @@ typedef BOOL (^GTIndexPathspecMatchedBlock)(NSString *matchedPathspec, NSString 
 			return NO;
 		}
 
-		GTIndexEntry *blockAncestor;
+		GTIndexEntry *blockAncestor = nil;
 		if (ancestor != NULL) {
 			blockAncestor = [[GTIndexEntry alloc] initWithGitIndexEntry:ancestor];
 		}
 
-		GTIndexEntry *blockOurs;
+		GTIndexEntry *blockOurs = nil;
 		if (ours != NULL) {
 			blockOurs = [[GTIndexEntry alloc] initWithGitIndexEntry:ours];
 		}
 
-		GTIndexEntry *blockTheirs;
+		GTIndexEntry *blockTheirs = nil;
 		if (theirs != NULL) {
 			blockTheirs = [[GTIndexEntry alloc] initWithGitIndexEntry:theirs];
 		}
@@ -336,10 +344,58 @@ struct GTIndexPathspecMatchedInfo {
 	BOOL shouldAbortImmediately;
 };
 
+- (BOOL)addPathspecs:(NSArray *)pathspecs flags:(GTIndexAddOptionFlags)flags error:(NSError **)error passingTest:(GTIndexPathspecMatchedBlock)block {
+	NSAssert(self.repository.isBare == NO, @"This method only works with non-bare repositories.");
+
+	__block git_strarray strarray = pathspecs.git_strarray;
+	@onExit {
+		if (strarray.count > 0) git_strarray_free(&strarray);
+	};
+
+	struct GTIndexPathspecMatchedInfo payload = {
+		.block = block,
+		.shouldAbortImmediately = NO,
+	};
+
+	int returnCode = git_index_add_all(self.git_index, &strarray, (unsigned int)flags, (block != nil ? GTIndexPathspecMatchFound : NULL), &payload);
+	if (returnCode != GIT_OK && returnCode != GIT_EUSER) {
+		if (error != nil) *error = [NSError git_errorFor:returnCode description:NSLocalizedString(@"Could not add to index.", nil)];
+		return NO;
+	}
+
+	return YES;
+}
+
+- (BOOL)removePathspecs:(NSArray *)pathspecs error:(NSError **)error passingTest:(GTIndexPathspecMatchedBlock)block {
+	NSAssert(self.repository.isBare == NO, @"This method only works with non-bare repositories.");
+
+	__block git_strarray strarray = pathspecs.git_strarray;
+	@onExit {
+		if (strarray.count > 0) git_strarray_free(&strarray);
+	};
+
+	struct GTIndexPathspecMatchedInfo payload = {
+		.block = block,
+		.shouldAbortImmediately = NO,
+	};
+
+	int returnCode = git_index_remove_all(self.git_index, &strarray, (block != nil ? GTIndexPathspecMatchFound : NULL), &payload);
+	if (returnCode != GIT_OK && returnCode != GIT_EUSER) {
+		if (error != nil) *error = [NSError git_errorFor:returnCode description:NSLocalizedString(@"Could not remove from index.", nil)];
+		return NO;
+	}
+
+	return YES;
+}
+
 - (BOOL)updatePathspecs:(NSArray *)pathspecs error:(NSError **)error passingTest:(GTIndexPathspecMatchedBlock)block {
 	NSAssert(self.repository.isBare == NO, @"This method only works with non-bare repositories.");
 
-	const git_strarray strarray = pathspecs.git_strarray;
+	__block git_strarray strarray = pathspecs.git_strarray;
+	@onExit {
+		if (strarray.count > 0) git_strarray_free(&strarray);
+	};
+
 	struct GTIndexPathspecMatchedInfo payload = {
 		.block = block,
 		.shouldAbortImmediately = NO,

--- a/ObjectiveGit/GTRepository+Status.h
+++ b/ObjectiveGit/GTRepository+Status.h
@@ -76,7 +76,7 @@ typedef NS_OPTIONS(NSInteger, GTRepositoryStatusFlags) {
 	GTRepositoryStatusFlagsNoRefresh = GIT_STATUS_OPT_NO_REFRESH,
 	GTRepositoryStatusFlagsUpdateIndex = GIT_STATUS_OPT_UPDATE_INDEX,
 	GTRepositoryStatusFlagsIncludeUnreadable = GIT_STATUS_OPT_INCLUDE_UNREADABLE,
-	GTRepositoryStatusFlagsIncludeUnreadableAsUntracked = GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED,
+	GTRepositoryStatusFlagsIncludeUnreadableAsUntracked = GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED
 };
 
 /// An `NSArray` of `NSStrings`s to limit the status to specific paths inside


### PR DESCRIPTION
- add missing GTIndex checksum getter
- add missing GTIndex add or update all method (with companion flags definition)
- add missing GTIndex remove all method
- fix ambiguousness of uninitialized parameters of conflicts iterator
- fix memory leaks of pathspec due to git_strarray misuse
- fix nullability qualifiers (and change comments appropriately) with respect to actual behaviour of pathspec shim callback